### PR TITLE
refactor

### DIFF
--- a/shadertoy.c
+++ b/shadertoy.c
@@ -4,7 +4,7 @@
 
 int main (
 	int argc,
-	char * * argv
+	char **argv
 ) {
 	if (argc != 2) {
 		puts("Usage: shadertoy <shaderfile>");
@@ -17,7 +17,7 @@ int main (
 		return 1;
 	}
 
-	GLFWwindow * window = glfwCreateWindow(640, 480, "Shadertoy", NULL, NULL);
+	GLFWwindow *window = glfwCreateWindow(640, 480, "Shadertoy", NULL, NULL);
 	if (window == NULL) {
 		puts("Window error");
 		return 1;
@@ -31,21 +31,21 @@ int main (
 		return 1;
 	}
 
-	GLuint vertexbuffer;
-	glGenBuffers(1, &vertexbuffer);
+	GLuint vertexBuffer;
+	glGenBuffers(1, &vertexBuffer);
 
 	GLfloat vertices [3][2] = {
 		{-1.0, -1.0}, {3.0, -1.0}, {-1.0, 3.0}
 	};
-	glBindBuffer(GL_ARRAY_BUFFER, vertexbuffer);
-	glBufferData(GL_ARRAY_BUFFER, sizeof vertices, &vertices, GL_STATIC_DRAW);
+	glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), &vertices, GL_STATIC_DRAW);
 	glEnableVertexAttribArray(0);
 	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
-	unsigned const bufferlen = 1024;
-	char buffer [bufferlen];
+  unsigned int const bufferLen = 1024;
+	char buffer [bufferLen];
 
-	char shadervertexsource [] =
+	char const shaderVertexSource[] =
 		"#version 110\n"
 		"attribute vec2 aposition;"
 		"varying vec2 vposition;"
@@ -53,30 +53,28 @@ int main (
 			"gl_Position = vec4(aposition, 0.0, 1.0);"
 			"vposition = aposition;"
 		"}";
-	GLint shadervertexsourcelen = sizeof shadervertexsource - 1;
-	GLchar const * shadervertexsourcep = shadervertexsource;
-	GLuint shadervertex = glCreateShader(GL_VERTEX_SHADER);
-	glShaderSource(shadervertex, 1, &shadervertexsourcep, &shadervertexsourcelen);
-	glCompileShader(shadervertex);
+	GLint shaderVertexSourceLen = sizeof(shaderVertexSource) - 1;
+	GLuint shaderVertex = glCreateShader(GL_VERTEX_SHADER);
+	glShaderSource(shaderVertex, 1, (const char* const*)&shaderVertexSource, &shaderVertexSourceLen);
+	glCompileShader(shaderVertex);
 
-	FILE * shaderfragmentfile = fopen(argv[1], "r");
-	unsigned shaderfragmentsourcelenmax = 1024;
-	char shaderfragmentsource [shaderfragmentsourcelenmax];
-	GLchar const * shaderfragmentsourcep = shaderfragmentsource;
-	GLint shaderfragmentsourcelen = fread(shaderfragmentsource, 1, shaderfragmentsourcelenmax, shaderfragmentfile);
-	fclose(shaderfragmentfile);
-	GLuint shaderfragment = glCreateShader(GL_FRAGMENT_SHADER);
-	glShaderSource(shaderfragment, 1, &shaderfragmentsourcep, &shaderfragmentsourcelen);
-	glCompileShader(shaderfragment);
-	glGetShaderInfoLog(shaderfragment, bufferlen, NULL, buffer);
+	FILE *shaderFragmentFile = fopen(argv[1], "r");
+  unsigned int const shaderFragmentSourceLenMax = 1024;
+	char shaderFragmentSource[shaderFragmentSourceLenMax];
+	GLint shaderFragmentSourceLen = fread(shaderFragmentSource, 1, sizeof(shaderFragmentSource), shaderFragmentFile);
+	fclose(shaderFragmentFile);
+	GLuint shaderFragment = glCreateShader(GL_FRAGMENT_SHADER);
+	glShaderSource(shaderFragment, 1, (const char* const*)&shaderFragmentSource, &shaderFragmentSourceLen);
+	glCompileShader(shaderFragment);
+	glGetShaderInfoLog(shaderFragment, sizeof(buffer), NULL, buffer);
 	fputs(buffer, stdout);
 
-	GLuint shaderprogram = glCreateProgram();
-	glAttachShader(shaderprogram, shadervertex);
-	glAttachShader(shaderprogram, shaderfragment);
-	glBindAttribLocation(shaderprogram, 0, "aposition");
-	glLinkProgram(shaderprogram);
-	glUseProgram(shaderprogram);
+	GLuint shaderProgram = glCreateProgram();
+	glAttachShader(shaderProgram, shaderVertex);
+	glAttachShader(shaderProgram, shaderFragment);
+	glBindAttribLocation(shaderProgram, 0, "aposition");
+	glLinkProgram(shaderProgram);
+	glUseProgram(shaderProgram);
 
 	while (1) {
 		glDrawArrays(GL_TRIANGLES, 0, 3);

--- a/test.c
+++ b/test.c
@@ -5,7 +5,7 @@
 
 void fpsshow (
 	struct timespec * t,
-	unsigned f
+	unsigned int f
 ) {
 	struct timespec tn;
 	clock_gettime(CLOCK_MONOTONIC, &tn);
@@ -35,7 +35,7 @@ int main (void) {
 
 	struct timespec t;
 	int time_error = clock_gettime(CLOCK_MONOTONIC, &t);
-	unsigned f = 0;
+	unsigned int f = 0;
 	if (time_error != 0) {
 		puts("Time error");
 		return 1;

--- a/test2.c
+++ b/test2.c
@@ -5,7 +5,7 @@
 
 void fpsshow (
 	struct timespec * t,
-	unsigned f
+	unsigned int f
 ) {
 	struct timespec tn;
 	clock_gettime(CLOCK_MONOTONIC, &tn);
@@ -33,7 +33,7 @@ int main (void) {
 
 	struct timespec t;
 	int time_error = clock_gettime(CLOCK_MONOTONIC, &t);
-	unsigned f = 0;
+	unsigned int f = 0;
 	if (time_error != 0) {
 		puts("Time error");
 		return 1;


### PR DESCRIPTION
Provides refactors. Notable changes:

* Always use `sizeof(x)` instead of `sizeof x` because the latter is ambiguous
* Changed all pointers to be right-aligned
* Change all `unsigned` to `unsigned int` - if you include `stdint.h` you should be able to use `uint32_t` to type fewer characters
* Provided the correct type casts for the array pointers
* Changed to camelCase
* Used `sizeof()` when it could be used on stack arrays instead of the constant.
